### PR TITLE
Fix/prep start

### DIFF
--- a/data/programs.json
+++ b/data/programs.json
@@ -18,7 +18,7 @@
         "infoMessage": "Attending info session and orientation is required prior to starting prep",
 
         "description": [
-          "Our Prep program is a 3 week introduction to coding. Over the two weeks you will encounter the basics of JavaScript and decide whether you believe software engineering is something you are interested in pursuing. There is no cost for the prep program so that everyone can at least try their hand at coding and see if it's for them."
+          "Our Prep program is a 3 week introduction to coding. Over the three weeks you will encounter the basics of JavaScript and decide whether you believe software engineering is something you are interested in pursuing. There is no cost for the prep program so that everyone can at least try their hand at coding and see if it's for them."
         ]
       },
       {

--- a/data/programs.json
+++ b/data/programs.json
@@ -15,7 +15,8 @@
       {
         "title": "Prep",
         "length": "3 Weeks / 36 Hours",
-        "nextStartDate": "August 1, 2022",
+        "infoMessage": "Attending info session and orientation is required prior to starting prep",
+
         "description": [
           "Our Prep program is a 3 week introduction to coding. Over the two weeks you will encounter the basics of JavaScript and decide whether you believe software engineering is something you are interested in pursuing. There is no cost for the prep program so that everyone can at least try their hand at coding and see if it's for them."
         ]

--- a/data/types/programs.d.ts
+++ b/data/types/programs.d.ts
@@ -1,7 +1,8 @@
 export interface ICourses {
   title: string;
   length: string;
-  nextStartDate: string;
+  nextStartDate?: string;
+  infoMessage?: string;
   description: string[];
 }
 

--- a/env.sample
+++ b/env.sample
@@ -18,6 +18,12 @@ WUFOO_CONTACT_FORM_ID=[WUFOO_CONTACT_FORM_ID]
 ## base64('username:password')
 WUFOO_TOKEN=[BASE64_WUFOO_TOKEN]
 
+GOOGLE_API_KEY=[GOOGLE_API_KEY]
+
+# Goole Service Account
 ## JSON.stringify object containing the `private_key` and `client_email` for the service account
 ## `JSON.stringify({ private_key: "...", client_email: "SERVICE_ACCOUNT_NAME@ORGANIZATION.iam.gserviceaccount.com" })`
+
 GOOGLE_SERVICE_ACCOUNT=[STRINGIFIED_GOOGLE_SERVICE_ACCOUNT_CREDS]
+
+

--- a/pages/infoSession/index.tsx
+++ b/pages/infoSession/index.tsx
@@ -1,18 +1,16 @@
-import dynamic from 'next/dynamic';
-import { GetStaticProps, NextPage } from 'next';
 import styled from 'styled-components';
-import axios from 'axios';
+import { GetStaticProps, NextPage } from 'next';
+import dynamic from 'next/dynamic';
 import Image from 'next/image';
+import Link from 'next/link';
 
 import { IInfoSession } from '@this/data/types/infoSession';
 import { ILogo } from '@this/data/types/logos';
 
 import { cardShadow, cardShadowLtr, cardShadowRtl } from '@this/src/theme/styled/mixins/shadows';
 import { getStaticAsset } from '@this/pages-api/static/[asset]';
-import { ISessionDates } from '@this/pages-api/infoSession/dates';
 import { Main, Section, Content } from '@this/components/layout';
-import { useEffect, useState } from 'react';
-import Link from 'next/link';
+import useInfoSession from '@this/src/hooks/useInfoSession';
 
 const WorkforceForm = dynamic(() => import('@this/src/Forms/Form.Workforce'));
 const Carousel = dynamic(() => import('@this/components/Elements/Carousel'));
@@ -22,11 +20,7 @@ interface InfoSessionProps extends IInfoSession {
 }
 
 const InfoSession: NextPage<InfoSessionProps> = ({ commonQuestions, logos }) => {
-  const [sessionDates, setSessionDates] = useState<ISessionDates[]>([]);
-
-  useEffect(() => {
-    axios.get('/api/infoSession/dates').then(({ data }) => setSessionDates(data));
-  }, []);
+  const sessionDates = useInfoSession();
   return (
     <Main>
       <InfoSessionStyles>

--- a/pages/programs/workforce.tsx
+++ b/pages/programs/workforce.tsx
@@ -123,7 +123,7 @@ const AdultPrograms: NextPage<AdultProgramsProps> = ({
                         name={quote.name}
                         role={quote.role}
                         logoSrc={theme.isLightMode ? quote.logoSrcLight : quote.logoSrcDark}
-                        logoHref='https://mumms.com/'
+                        logoHref={quote.logoHref}
                       />
                     </MacCard>
                   </div>

--- a/pages/programs/workforce.tsx
+++ b/pages/programs/workforce.tsx
@@ -105,56 +105,60 @@ const AdultPrograms: NextPage<AdultProgramsProps> = ({
         <Section className='employer-love'>
           <Content style={{ paddingTop: '2rem', paddingBottom: '2rem' }}>
             <h1 className='dynamic-h1'>Employers love our grads!</h1>
-            <TwoColumns
-              style={{ height: '48rem' }}
-              leftColStyle={{ width: '60%', paddingRight: '2rem' }}
-              rightColStyle={{ width: '40%', paddingLeft: '2rem' }}
-              leftCol={
-                <div className='left-col'>
-                  <MacCard onNextClick={() => handleShift(1)} onPrevClick={() => handleShift(-1)}>
-                    <MacContent
-                      body={quote.body}
-                      imageUrl={quote.imageUrl}
-                      name={quote.name}
-                      role={quote.role}
-                      logoSrc={theme.isLightMode ? quote.logoSrcLight : quote.logoSrcDark}
-                      logoHref='https://mumms.com/'
-                    />
-                  </MacCard>
-                </div>
-              }
-              rightCol={
-                <div className='right-col-container'>
-                  <div className='right-col'>
-                    <p
-                      className='dynamic-txt'
-                      style={{
-                        paddingBottom: '1rem',
-                        maxWidth: '100%',
-
-                        color: 'rgba(25,25,25,1)',
-                      }}
+            <div className='employer-love-content'>
+              <TwoColumns
+                leftColStyle={{ width: '65%', paddingRight: '2rem' }}
+                rightColStyle={{ width: '35%', paddingLeft: '2rem' }}
+                leftCol={
+                  <div className='left-col'>
+                    <MacCard
+                      onNextClick={() => handleShift(1)}
+                      onPrevClick={() => handleShift(-1)}
+                      onPauseClick={() => setIsPaused(!isPaused)}
+                      isPaused={isPaused}
                     >
-                      <b>
-                        Does your company need developers? We foster employer partnerships in the
-                        community. Become a partner and gain valuable talent for your company.
-                      </b>
-                    </p>
-                    <Link href='/contact'>
-                      <a
-                        className='anchor right-arr-left'
-                        aria-label='Contact to learn about employer partnerships'
-                        title='Contact to learn about employer partnerships'
-                      >
-                        Contact us to learn more about
-                        <br />
-                        employer partnerships
-                      </a>
-                    </Link>
+                      <MacContent
+                        body={quote.body}
+                        imageUrl={quote.imageUrl}
+                        name={quote.name}
+                        role={quote.role}
+                        logoSrc={theme.isLightMode ? quote.logoSrcLight : quote.logoSrcDark}
+                        logoHref='https://mumms.com/'
+                      />
+                    </MacCard>
                   </div>
-                </div>
-              }
-            ></TwoColumns>
+                }
+                rightCol={
+                  <div className='right-col-container'>
+                    <div className='right-col'>
+                      <p
+                        className='dynamic-txt'
+                        style={{
+                          paddingBottom: '1rem',
+                          maxWidth: '100%',
+
+                          color: 'rgba(25,25,25,1)',
+                        }}
+                      >
+                        <b>
+                          Does your company need developers? We foster employer partnerships in the
+                          community. Become a partner and gain valuable talent for your company.
+                        </b>
+                      </p>
+                      <Link href='/contact'>
+                        <a
+                          className='anchor right-arr-left'
+                          aria-label='Contact to learn about employer partnerships'
+                          title='Contact to learn about employer partnerships'
+                        >
+                          Contact us to learn more about employer partnerships
+                        </a>
+                      </Link>
+                    </div>
+                  </div>
+                }
+              />
+            </div>
           </Content>
         </Section>
         <Section className='adult-courses'>
@@ -258,8 +262,14 @@ export const AdultProgramsStyles = styled.div`
     }
   }
   .employer-love {
+    min-height: 50rem;
+
+    .employer-love-content {
+    }
     background: ${({ theme }) => theme.secondary[500]};
     display: flex;
+    flex-flow: column;
+    justify-content: space-between;
 
     h1 {
       color: ${({ theme }) => theme.primary[700]};
@@ -313,9 +323,10 @@ export const AdultProgramsStyles = styled.div`
 
   @media screen and (max-width: 1000px) {
     .employer-love {
+      min-height: 60rem;
       .cols-2 {
         flex-flow: column;
-
+        justify-content: space-between;
         .left-col,
         .right-col {
           display: flex;
@@ -328,12 +339,15 @@ export const AdultProgramsStyles = styled.div`
         .right-col {
           flex-flow: column;
           align-items: center;
+
         }
       }
     }
   }
   @media screen and (max-width: 768px) {
     .employer-love {
+      align-items: center;
+      justify-content: center;
       .cols-2 {
         flex-flow: column;
         .left-col {

--- a/pages/programs/workforce.tsx
+++ b/pages/programs/workforce.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react';
 import { GetStaticProps, NextPage } from 'next';
 import Link from 'next/link';
 import styled, { useTheme } from 'styled-components';
+import moment from 'moment';
 
 import { Main, Section, Content } from '@this/components/layout';
 import { getStaticAsset } from '@this/pages-api/static/[asset]';
@@ -13,6 +14,7 @@ import { TwoColumns } from '@this/components/Elements/Columns';
 import { IQuote, ITitleDescription } from '@this/data/types/bits';
 import { ICourses } from '@this/data/types/programs';
 import { BgImg } from '@this/src/components/Elements';
+import useInfoSession from '@this/src/hooks/useInfoSession';
 
 export interface AdultProgramsProps {
   header: ITitleDescription;
@@ -31,6 +33,12 @@ const AdultPrograms: NextPage<AdultProgramsProps> = ({
   const [quoteIndex, setQuoteIndex] = useState(0);
   const [isPaused, setIsPaused] = useState(false);
   const quote = companyQuotes[quoteIndex];
+
+  const nextInfoSession = useInfoSession(true);
+
+  const nextInfoSessionDate = !nextInfoSession
+    ? null
+    : moment(nextInfoSession.times.start.dateTime).format('dddd, MMMM Do @ h:mma');
 
   useEffect(() => {
     let interval: NodeJS.Timer;
@@ -161,7 +169,7 @@ const AdultPrograms: NextPage<AdultProgramsProps> = ({
             </a>
 
             <h1 className='dynamic-h1'>Courses</h1>
-            {courses.map(({ title, length, description, nextStartDate }) => (
+            {courses.map(({ title, length, description, nextStartDate, infoMessage }) => (
               <PlainCard
                 className='program-card _progress'
                 id={title.toLowerCase().split(' ').join('-')}
@@ -178,6 +186,23 @@ const AdultPrograms: NextPage<AdultProgramsProps> = ({
                       {desc}
                     </p>
                   ))}
+                  {infoMessage && (
+                    <div>
+                      <p className='dynamic-txt'>
+                        <b>{infoMessage}</b>
+                      </p>
+                      <div>
+                        <p className='dynamic-txt program-next-start primary-secondary'>
+                          <b>Next info session: {nextInfoSessionDate}</b>
+                        </p>
+                      </div>
+                      <p className='dynamic-txt program-next-start primary-secondary'>
+                        <Link href='/infoSession'>
+                          <a className='anchor right-arr-left'>Sign up here</a>
+                        </Link>
+                      </p>
+                    </div>
+                  )}
                   {nextStartDate && (
                     <p className='dynamic-txt primary-secondary program-next-start'>
                       <b>Next start date: {nextStartDate}</b>

--- a/pages/programs/workforce.tsx
+++ b/pages/programs/workforce.tsx
@@ -98,19 +98,22 @@ const AdultPrograms: NextPage<AdultProgramsProps> = ({
           <Content style={{ paddingTop: '2rem', paddingBottom: '2rem' }}>
             <h1 className='dynamic-h1'>Employers love our grads!</h1>
             <TwoColumns
+              style={{ height: '48rem' }}
               leftColStyle={{ width: '60%', paddingRight: '2rem' }}
               rightColStyle={{ width: '40%', paddingLeft: '2rem' }}
               leftCol={
-                <MacCard onNextClick={() => handleShift(1)} onPrevClick={() => handleShift(-1)}>
-                  <MacContent
-                    body={quote.body}
-                    imageUrl={quote.imageUrl}
-                    name={quote.name}
-                    role={quote.role}
-                    logoSrc={theme.isLightMode ? quote.logoSrcLight : quote.logoSrcDark}
-                    logoHref='https://mumms.com/'
-                  />
-                </MacCard>
+                <div className='left-col'>
+                  <MacCard onNextClick={() => handleShift(1)} onPrevClick={() => handleShift(-1)}>
+                    <MacContent
+                      body={quote.body}
+                      imageUrl={quote.imageUrl}
+                      name={quote.name}
+                      role={quote.role}
+                      logoSrc={theme.isLightMode ? quote.logoSrcLight : quote.logoSrcDark}
+                      logoHref='https://mumms.com/'
+                    />
+                  </MacCard>
+                </div>
               }
               rightCol={
                 <div className='right-col-container'>
@@ -231,11 +234,15 @@ export const AdultProgramsStyles = styled.div`
   }
   .employer-love {
     background: ${({ theme }) => theme.secondary[500]};
-    min-height: 42rem;
     display: flex;
 
     h1 {
       color: ${({ theme }) => theme.primary[700]};
+    }
+    .left-col {
+      display: flex;
+      align-items: center;
+      height: 100%;
     }
     .right-col-container {
       display: flex;

--- a/pages/programs/workforce.tsx
+++ b/pages/programs/workforce.tsx
@@ -264,19 +264,22 @@ export const AdultProgramsStyles = styled.div`
   .employer-love {
     min-height: 50rem;
 
-    .employer-love-content {
-    }
+
     background: ${({ theme }) => theme.secondary[500]};
     display: flex;
-    flex-flow: column;
-    justify-content: space-between;
 
+
+    .employer-love-content {
+      height: 90%;
+      align-items: space-between;
+      display: flex;
+    }
     h1 {
       color: ${({ theme }) => theme.primary[700]};
     }
     .left-col {
       display: flex;
-      align-items: center;
+      align-items: flex-start;
       height: 100%;
     }
     .right-col-container {
@@ -346,8 +349,7 @@ export const AdultProgramsStyles = styled.div`
   }
   @media screen and (max-width: 768px) {
     .employer-love {
-      align-items: center;
-      justify-content: center;
+
       .cols-2 {
         flex-flow: column;
         .left-col {

--- a/src/components/Cards/MacCard.tsx
+++ b/src/components/Cards/MacCard.tsx
@@ -1,16 +1,26 @@
 import { ReactNode } from 'react';
 import styled, { useTheme } from 'styled-components';
-import { FaArrowRight, FaArrowLeft } from 'react-icons/fa';
+import { FaArrowRight as RightIcon, FaArrowLeft as LeftIcon } from 'react-icons/fa';
+import { IoMdPause as PauseIcon, IoMdPlay as PlayIcon } from 'react-icons/io';
 
 import { SlashDivider } from '@this/components/Elements/SlashDivider';
 
 interface MacCardProps {
   onNextClick?: () => void;
   onPrevClick?: () => void;
+  onPauseClick?: () => void;
+  isPaused: boolean;
   children: ReactNode | ReactNode[] | undefined;
 }
 
-export const MacCard = ({ children, onNextClick, onPrevClick }: MacCardProps) => {
+export const MacCard = ({
+  children,
+  onNextClick,
+  onPrevClick,
+  onPauseClick,
+  isPaused,
+}: MacCardProps) => {
+  const pauseOrPlay = isPaused ? 'play' : 'pause';
   return (
     <MacCardStyles>
       <SlashDivider
@@ -22,7 +32,7 @@ export const MacCard = ({ children, onNextClick, onPrevClick }: MacCardProps) =>
         }}
       >
         <div className='mac-buttons'>
-          <MacBtn fill='yellow' />
+          <MacBtn fill='yellow' char={onPauseClick && pauseOrPlay} onClick={onPauseClick} />
           <MacBtn char={onPrevClick && '<'} onClick={onPrevClick} />
           <MacBtn char={onNextClick && '>'} onClick={onNextClick} />
         </div>
@@ -40,28 +50,34 @@ const MacBtn = ({
   onClick,
 }: {
   fill?: 'yellow';
-  char?: '<' | '>' | undefined;
+  char?: '<' | '>' | 'pause' | 'play' | undefined;
   onClick?: () => void;
 }) => {
+  const icons = {
+    '<': LeftIcon,
+    '>': RightIcon,
+    pause: PauseIcon,
+    play: PlayIcon,
+  };
+  const BtnIcon = char ? icons[char] : null;
   const theme = useTheme();
 
   return (
     <MacBtnStyles>
-      {char ? (
+      {BtnIcon ? (
         <button
-          className='mac-button'
-          style={fill === 'yellow' ? { background: theme.yellow[400] } : {}}
-          disabled={!char}
+          className={`mac-button${fill === 'yellow' ? ' invert' : ''}`}
+          style={fill === 'yellow' ? { background: theme.yellow[400], color: theme.black } : {}}
           aria-label={char === '<' ? 'Previous' : ' Next'}
           onClick={() => onClick?.()}
         >
-          {char === '<' ? <FaArrowLeft size={10} /> : <FaArrowRight size={10} />}
+          <BtnIcon size={10} />
         </button>
       ) : (
         <div
           tabIndex={-1}
           className='mac-no-button'
-          style={fill === 'yellow' ? { background: theme.yellow[400] } : {}}
+          style={fill === 'yellow' ? { background: theme.yellow[400] } : undefined}
         ></div>
       )}
     </MacBtnStyles>

--- a/src/components/Cards/MacCard.tsx
+++ b/src/components/Cards/MacCard.tsx
@@ -9,7 +9,7 @@ interface MacCardProps {
   onNextClick?: () => void;
   onPrevClick?: () => void;
   onPauseClick?: () => void;
-  isPaused: boolean;
+  isPaused?: boolean;
   children: ReactNode | ReactNode[] | undefined;
 }
 

--- a/src/components/Cards/content/MacContent.tsx
+++ b/src/components/Cards/content/MacContent.tsx
@@ -1,18 +1,38 @@
 import Image from 'next/image';
+import { useEffect, useRef, useState } from 'react';
 import styled from 'styled-components';
+import { motion } from 'framer-motion';
+
 import { Zap } from '@this/components/Elements/ZapIcon';
 import { IQuote } from '@this/data/types/bits';
-import { motion } from 'framer-motion';
 
 type MacContentProps = Omit<IQuote, 'logoSrcDark' | 'logoSrcLight'> & {
   logoSrc?: string;
 };
 
 export const MacContent = ({ body, name, role, imageUrl, logoHref, logoSrc }: MacContentProps) => {
+  const [overflowHeight, setOverflowHeight] = useState<number>(0);
+  const bodyRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    bodyRef.current && setOverflowHeight(bodyRef.current.scrollHeight);
+  }, [body]);
+
   return (
     <MacContentStyles>
       <div className='mac-card-main'>
-        <div className='mac-card-body dynamic-txt'>&ldquo;{body}&rdquo;</div>
+        <motion.div
+          className='mac-card-body dynamic-txt'
+          ref={bodyRef}
+          animate={{
+            maxHeight: `${overflowHeight}px`,
+            height: '100%',
+          }}
+          transition={{ duration: 0.2, type: 'tween' }}
+        >
+          &ldquo;{body}&rdquo;
+        </motion.div>
+
         {imageUrl && (
           <div className='mac-card-image'>
             <Image objectFit='contain' layout='fill' src={imageUrl} alt='' />
@@ -56,13 +76,14 @@ const MacContentStyles = styled(motion.div)`
   .mac-card-main {
     display: flex;
     height: 100%;
-
+    position: relative;
     .mac-card-body {
+      display: flex;
+      flex-flow: row wrap;
       padding: 1rem;
+      overflow: hidden;
       font-weight: 400;
       font-style: italic;
-      height: 100%;
-      display: flex;
     }
     .mac-card-image {
       min-width: 175px;

--- a/src/components/Elements/Columns.tsx
+++ b/src/components/Elements/Columns.tsx
@@ -5,6 +5,7 @@ const TwoColumnsStyles = styled.div`
   display: flex;
   width: 100%;
   justify-content: space-between;
+
   @media screen and (max-width: 1000px) {
     flex-flow: column;
     width: 100%;
@@ -33,6 +34,7 @@ interface TwoColumnsProps {
   rightCol: ReactNode;
   leftColStyle?: CSSProperties;
   rightColStyle?: CSSProperties;
+  style?: CSSProperties;
 }
 
 export const TwoColumns = ({
@@ -40,9 +42,10 @@ export const TwoColumns = ({
   rightCol,
   leftColStyle,
   rightColStyle,
+  style
 }: TwoColumnsProps) => {
   return (
-    <TwoColumnsStyles>
+    <TwoColumnsStyles style={style}>
       <Column style={leftColStyle}>{leftCol}</Column>
       <Column style={rightColStyle}>{rightCol}</Column>
     </TwoColumnsStyles>

--- a/src/hooks/useInfoSession.ts
+++ b/src/hooks/useInfoSession.ts
@@ -14,7 +14,7 @@ function useInfoSession(nextOnly?: boolean) {
   }, []);
 
   if (nextOnly) {
-    return sessionDates[0] || null;
+    return sessionDates[0] ?? null;
   }
   return sessionDates;
 }

--- a/src/hooks/useInfoSession.ts
+++ b/src/hooks/useInfoSession.ts
@@ -1,0 +1,22 @@
+import axios from 'axios';
+import { useEffect, useState } from 'react';
+
+import { ISessionDates } from '@this/pages-api/infoSession/dates';
+
+function useInfoSession(nextOnly: boolean): ISessionDates;
+function useInfoSession(): ISessionDates[];
+
+function useInfoSession(nextOnly?: boolean) {
+  const [sessionDates, setSessionDates] = useState<ISessionDates[]>([]);
+
+  useEffect(() => {
+    axios.get('/api/infoSession/dates').then(({ data }) => setSessionDates(data));
+  }, []);
+
+  if (nextOnly) {
+    return sessionDates[0] || null;
+  }
+  return sessionDates;
+}
+
+export default useInfoSession;


### PR DESCRIPTION
- Minor updates to MacCard element
- Fix page jitter on MacCard resize/transition
- Change "Prep start date" → "Next Info Session Date"
  - **TODO:** Update greenlight webhook for info session dates to remove the upcoming date/time 1 hour prior to start
- Add an optional `infoMessage` property to course info, designed only to be used for prep. 
   > "Attending info session and orientation is required prior to starting prep"