### PR TITLE
send locationType and googlePlace with other session info

### DIFF
--- a/pages/api/infoSession/dates.ts
+++ b/pages/api/infoSession/dates.ts
@@ -1,6 +1,7 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import axios from 'axios';
 import { config } from '../config';
+import { GooglePlace, LocationType } from './user';
 
 const { GREENLIGHT_API_ENDPOINT } = config;
 export interface ISessionDates {
@@ -18,6 +19,8 @@ export interface ISessionDates {
     };
     until: string;
   };
+  googlePlace: GooglePlace;
+  locationType: LocationType;
 }
 
 export default async function infoSession(

--- a/pages/api/infoSession/dates.ts
+++ b/pages/api/infoSession/dates.ts
@@ -28,7 +28,7 @@ export default async function infoSession(
   res: NextApiResponse<ISessionDates[]>,
 ) {
   const sessionDates = await getInfoSessionDates();
-  if (!sessionDates.length) {
+  if (!sessionDates?.length) {
     return res.status(404).end();
   }
   return res.status(200).json(sessionDates);

--- a/pages/api/infoSession/user.ts
+++ b/pages/api/infoSession/user.ts
@@ -14,7 +14,7 @@ interface ISession {
   startDateTime: string;
   programId: string;
   locationType: LocationType;
-  googlePlace: GooglePlace;
+  googlePlace?: GooglePlace;
 }
 
 export type LocationType = 'HYBRID' | 'IN_PERSON' | 'VIRTUAL';
@@ -41,7 +41,6 @@ export type FormDataSignup = {
 };
 
 export interface ISessionSignup {
-  [key: string]: string | undefined;
   programId: string;
   nameFirst: string;
   nameLast: string;
@@ -51,6 +50,8 @@ export interface ISessionSignup {
   referrerResponse: string;
   startDateTime?: string;
   cohort: string;
+  googlePlace?: GooglePlace;
+  locationType?: LocationType;
   sessionId: string;
   token: string;
 }
@@ -65,6 +66,7 @@ export default async function handleInfoSessionForm(req: ISessionUser, res: Next
         'X-Greenlight-Signup-Api-Key': GREENLIGHT_API_TOKEN,
       },
     });
+
     res.status(200).end();
   } catch (error) {
     console.error('Could not POST to signup service', error);
@@ -74,6 +76,11 @@ export default async function handleInfoSessionForm(req: ISessionUser, res: Next
 
 function formatPayload(form: FormDataSignup): ISessionSignup {
   const { session, email, firstName, lastName, phone, referencedBy } = form;
+
+  // Sometimes greenlight returns an empty string rather than a google place object
+  if (typeof session?.googlePlace === 'string') {
+    session.googlePlace = undefined;
+  }
 
   return {
     nameFirst: firstName,
@@ -87,6 +94,7 @@ function formatPayload(form: FormDataSignup): ISessionSignup {
     referrerResponse: referencedBy.additionalInfo,
     referrer: referencedBy?.value,
     locationType: session?.locationType,
+    googlePlace: session?.googlePlace,
     token: GREENLIGHT_API_TOKEN ?? '',
   };
 }

--- a/pages/api/infoSession/user.ts
+++ b/pages/api/infoSession/user.ts
@@ -13,7 +13,23 @@ interface ISession {
   cohort: string;
   startDateTime: string;
   programId: string;
+  locationType: LocationType;
+  googlePlace: GooglePlace;
 }
+
+export type LocationType = 'HYBRID' | 'IN_PERSON' | 'VIRTUAL';
+
+export type GooglePlace = {
+  placesId: string;
+  name: string;
+  address: string;
+  phone: string;
+  website: string;
+  geometry: {
+    lat: number;
+    lng: number;
+  };
+};
 
 export type FormDataSignup = {
   session?: ISession;
@@ -70,6 +86,7 @@ function formatPayload(form: FormDataSignup): ISessionSignup {
     cohort: session?.cohort ?? '',
     referrerResponse: referencedBy.additionalInfo,
     referrer: referencedBy?.value,
+    locationType: session?.locationType,
     token: GREENLIGHT_API_TOKEN ?? '',
   };
 }

--- a/src/Forms/Form.Workforce.tsx
+++ b/src/Forms/Form.Workforce.tsx
@@ -25,7 +25,6 @@ const WorkforceForm = ({ sessionDates }: WorkforceFormProps) => {
     const { sessionDate, ...values } = form.values();
 
     const session = sessionDates.find((s) => s._id === sessionDate.value);
-
     const body: FormDataSignup = {
       ...values,
       ...(session && {
@@ -34,6 +33,8 @@ const WorkforceForm = ({ sessionDates }: WorkforceFormProps) => {
           cohort: session.cohort,
           programId: session.programId,
           startDateTime: session.times.start.dateTime,
+          googlePlace: session.googlePlace,
+          locationType: session.locationType,
         },
       }),
     };

--- a/src/api/googleFunctions.ts
+++ b/src/api/googleFunctions.ts
@@ -1,12 +1,12 @@
 import { GoogleAuth } from 'google-auth-library';
 
-export type RunCloudFunctionArgs = {
+export type RunCloudFunctionArgs<T> = {
   url: string;
-  body: { [key: string]: string | undefined };
+  body: T;
   headers?: { [key: string]: string | undefined };
 };
 
-export const runCloudFunction = async ({ url, body, headers = {} }: RunCloudFunctionArgs) => {
+export async function runCloudFunction<T>({ url, body, headers = {} }: RunCloudFunctionArgs<T>) {
   const { GOOGLE_SERVICE_ACCOUNT } = process.env;
   const credentials = GOOGLE_SERVICE_ACCOUNT && JSON.parse(GOOGLE_SERVICE_ACCOUNT);
   if (!credentials) {
@@ -24,4 +24,4 @@ export const runCloudFunction = async ({ url, body, headers = {} }: RunCloudFunc
     },
     body: JSON.stringify(body),
   });
-};
+}

--- a/src/api/googleFunctions.ts
+++ b/src/api/googleFunctions.ts
@@ -15,7 +15,6 @@ export const runCloudFunction = async ({ url, body, headers = {} }: RunCloudFunc
 
   const auth = new GoogleAuth({ credentials });
   const client = await auth.getIdTokenClient(url);
-
   await client.request({
     url,
     method: 'POST',


### PR DESCRIPTION
Resolves #39 
Send over location type and googlePlace with the rest of session data

Payload example:
```json
{
  "nameFirst": "Taylor",
  "nameLast": "Shephard",
  "email": "",
  "cell": "",
  "sessionId": "ia6cThnvPZ6MygTgf",
  "programId": "5sTmB97DzcqCwEZFR",
  "startDateTime": "2022-12-05T17:00:00.000Z",
  "cohort": "is-dec-5-22-12pm",
  "referrerResponse": "",
  "referrer": "google",
  "locationType": "HYBRID",
  "googlePlace": {
    "placesId": "ChIJ7YchCHSmIIYRYsAEPZN_E0o",
    "name": "Operation Spark",
    "address": "514 Franklin Ave, New Orleans, LA 70117, USA",
    "phone": "+1 504-534-8277",
    "website": "https://www.operationspark.org/",
    "geometry": { "lat": 29.96325999999999, "lng": -90.052138 }
  },
  "token": ""
}
```
