### PR TITLE
stack dates evenly + limit list size for each course

### DIFF
--- a/pages/programs/workforce/schedule.tsx
+++ b/pages/programs/workforce/schedule.tsx
@@ -129,7 +129,7 @@ const CohortSchedule: NextPage = () => {
 
                       {course && groupBy === 'course' && <CourseInfo course={course} />}
                     </div>
-                    {courses?.map(
+                    {courses?.slice(0, 4)?.map(
                       (s) =>
                         s &&
                         !s.isPast && (
@@ -234,19 +234,22 @@ export const CohortScheduleStyles = styled.div`
   }
 
   .schedule-container {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(18rem, auto));
-    grid-template-rows: auto;
+    display: flex;
+    flex-flow: row wrap;
+    /* grid-template-columns: repeat(auto-fill, minmax(18rem, auto));
+    grid-template-rows: 1fr; */
 
     padding: 1rem;
     grid-gap: 1.5rem;
     margin: 0 auto;
   }
   .schedule-cohort {
-    width: 100%;
+    flex: 1;
+    min-width: 18rem;
   }
   .schedule-cohort-container {
     width: 100%;
+
     display: flex;
     flex-flow: column;
     grid-gap: 0.5rem;

--- a/pages/programs/workforce/schedule.tsx
+++ b/pages/programs/workforce/schedule.tsx
@@ -129,6 +129,8 @@ const CohortSchedule: NextPage = () => {
 
                       {course && groupBy === 'course' && <CourseInfo course={course} />}
                     </div>
+
+                    {/* Limit list size when filtering by course only. When filtering by cohort, slicing will prevent shoing every phase */}
                     {(groupBy === 'course' ? courses?.slice(0, 5) : courses)?.map(
                       (s) =>
                         s &&

--- a/pages/programs/workforce/schedule.tsx
+++ b/pages/programs/workforce/schedule.tsx
@@ -129,7 +129,7 @@ const CohortSchedule: NextPage = () => {
 
                       {course && groupBy === 'course' && <CourseInfo course={course} />}
                     </div>
-                    {courses?.slice(0, 4)?.map(
+                    {(groupBy === 'course' ? courses?.slice(0, 5) : courses)?.map(
                       (s) =>
                         s &&
                         !s.isPast && (


### PR DESCRIPTION
Update workforce schedule to be consistent in length + remove stagger in lists
- only show up to 5 upcoming cohorts

<a href="https://testing.operationspark.org/programs/workforce/schedule" target="_blank">Preview here</a>

![image](https://user-images.githubusercontent.com/37914211/207415270-cfdefb03-f1b8-4c99-ad72-c16a629be026.png)
