### PR TITLE
Feat/private info session

### DIFF
--- a/pages/api/infoSession/dates.ts
+++ b/pages/api/infoSession/dates.ts
@@ -8,6 +8,7 @@ export interface ISessionDates {
   _id: string;
   cohort: string;
   programId: string;
+  private?: boolean;
   times: {
     start: {
       dateTime: string;

--- a/src/Forms/Form.Workforce.tsx
+++ b/src/Forms/Form.Workforce.tsx
@@ -11,6 +11,7 @@ import Button from '@this/components/Elements/Button';
 import unitedStates from './formData/unitedStates.json';
 import Spinner from '../components/Elements/Spinner';
 import { pixel } from '@this/lib/pixel';
+import useKeyCombo from '../hooks/useKeyCombo';
 
 interface WorkforceFormProps {
   sessionDates: ISessionDates[];
@@ -19,6 +20,8 @@ interface WorkforceFormProps {
 const WorkforceForm = ({ sessionDates }: WorkforceFormProps) => {
   const form = useForm<IInfoSessionFormValues>();
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const isKeyComboActive = useKeyCombo('o', 's');
+
   const handleSubmit = () => {
     const hasErrors = form.hasErrors();
 
@@ -69,7 +72,7 @@ const WorkforceForm = ({ sessionDates }: WorkforceFormProps) => {
 
   const sessionDateOptions = [
     ...sessionDates
-      .filter((s) => !s.private)
+      .filter((s) => !s.private || isKeyComboActive)
       .map((session) => ({
         name: moment(session.times.start.dateTime).format('dddd, MMMM Do h:mma'),
         value: session._id,

--- a/src/Forms/Form.Workforce.tsx
+++ b/src/Forms/Form.Workforce.tsx
@@ -53,7 +53,9 @@ const WorkforceForm = ({ sessionDates }: WorkforceFormProps) => {
     axios
       .post('/api/infoSession/user', body)
       .then(() => {
-        form.notifySuccess();
+        form.notifySuccess({
+          msg: 'Info session registration for submitted. You should receive an email and text message shortly.',
+        });
         form.clear();
       })
       .catch(() => {
@@ -66,10 +68,12 @@ const WorkforceForm = ({ sessionDates }: WorkforceFormProps) => {
   };
 
   const sessionDateOptions = [
-    ...sessionDates.map(({ _id, times: { start } }) => ({
-      name: moment(start.dateTime).format('dddd, MMMM Do h:mma'),
-      value: _id,
-    })),
+    ...sessionDates
+      .filter((s) => !s.private)
+      .map((session) => ({
+        name: moment(session.times.start.dateTime).format('dddd, MMMM Do h:mma'),
+        value: session._id,
+      })),
     {
       name: 'None of these fit my schedule',
       value: 'future',

--- a/src/components/Form/useForm.ts
+++ b/src/components/Form/useForm.ts
@@ -2,40 +2,28 @@ import { useState } from 'react';
 import { useToast } from '@chakra-ui/react';
 import { TOption } from '@this/data/types/bits';
 
-type IValues<T> = {
-  [Property in keyof T]: string;
-};
+type IValues<Values, T extends keyof Values> = Record<T, string>;
+type ISelectValues = Record<string, TOption>;
+type TCheckboxes = Record<string, boolean>;
+type TCheckboxGroup = Record<string, TCheckboxes>;
+type IValidation = Record<string, boolean>;
 
-type ISelectValues<T> = Record<keyof T, T[keyof T]>;
-
-type TCheckboxes = {
-  [key: string]: boolean;
-};
-
-type TCheckboxGroup = {
-  [key: string]: TCheckboxes;
-};
-
-interface IValidation {
-  [key: string]: boolean;
-}
-
-interface INotify {
+type INotify = {
   title?: string;
   msg?: string;
-}
+};
 
-interface OnSelectChangeProps {
+type OnSelectChangeProps = {
   option?: TOption;
   additionalInfo?: string;
   additionalInfoLabel?: string;
   isValid: boolean;
-}
+};
 
-const useForm = <T extends Record<keyof T, T[keyof T]>>() => {
+const useForm = <T extends Record<keyof T, T[keyof T]> = {}>() => {
   const toast = useToast();
-  const [values, setValues] = useState<IValues<T>>({} as T);
-  const [selectValues, setSelectValues] = useState<ISelectValues<T>>({} as T);
+  const [values, setValues] = useState<IValues<T, keyof T>>({} as T);
+  const [selectValues, setSelectValues] = useState<ISelectValues>({});
   const [checkboxGroupValues, setCheckboxGroupValues] = useState<TCheckboxGroup>({} as T);
   const [checkboxValues, setCheckboxValues] = useState<TCheckboxes>({} as T);
   const [validation, setValidation] = useState<IValidation>({});
@@ -46,8 +34,7 @@ const useForm = <T extends Record<keyof T, T[keyof T]>>() => {
     get: (name: string): string => values[name as keyof T] || '',
 
     /** Fetches values for provided `select` property (key) */
-    getSelect: (name: keyof T): TOption =>
-      selectValues[name] ? selectValues[name] : { value: '', name: '' },
+    getSelect: (name: string): TOption => selectValues[name] ?? { value: '', name: '' },
 
     /** Fetches values for provided `checkboxes` property (key) */
     getCheckboxes: (name: string): TCheckboxes => checkboxGroupValues[name] || {},
@@ -82,10 +69,11 @@ const useForm = <T extends Record<keyof T, T[keyof T]>>() => {
     onSelectChange:
       (name: string) =>
       ({ option, additionalInfo, additionalInfoLabel, isValid }: OnSelectChangeProps) => {
-        setSelectValues({
-          ...selectValues,
-          [name]: { ...option, additionalInfo, additionalInfoLabel },
-        });
+        option &&
+          setSelectValues({
+            ...selectValues,
+            [name]: { ...option, additionalInfo, additionalInfoLabel },
+          });
         setValidation({ ...validation, [name]: isValid });
       },
 

--- a/src/components/Form/useForm.ts
+++ b/src/components/Form/useForm.ts
@@ -46,11 +46,8 @@ const useForm = <T extends Record<keyof T, T[keyof T]>>() => {
     get: (name: string): string => values[name as keyof T] || '',
 
     /** Fetches values for provided `select` property (key) */
-    getSelect: (name: string): TOption =>
-      selectValues[name as keyof T] || {
-        value: '',
-        name: '',
-      },
+    getSelect: (name: keyof T): TOption =>
+      selectValues[name] ? selectValues[name] : { value: '', name: '' },
 
     /** Fetches values for provided `checkboxes` property (key) */
     getCheckboxes: (name: string): TCheckboxes => checkboxGroupValues[name] || {},

--- a/src/hooks/useKeyCombo.ts
+++ b/src/hooks/useKeyCombo.ts
@@ -10,7 +10,6 @@ export const useKeyCombo = (...keys: string[]) => {
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
       const key = e.key.toLocaleLowerCase('en-US');
-      console.log(key);
       if (key === lastKey) {
         return;
       }

--- a/src/hooks/useKeyCombo.ts
+++ b/src/hooks/useKeyCombo.ts
@@ -1,0 +1,50 @@
+import { useState, useEffect } from 'react';
+
+export const useKeyCombo = (...keys: string[]) => {
+  const [isCtrl, setCtrl] = useState(false);
+  const [isOpt, setOpt] = useState(false);
+  const [lastKey, setLastKey] = useState('');
+  const [currentCombos, setCurrentCombos] = useState<string[]>([]);
+  const [isActive, setIsActive] = useState<boolean>(false);
+
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      const key = e.key.toLocaleLowerCase();
+      if (key === lastKey) {
+        return;
+      }
+      if (key === 'control') {
+        return setCtrl(true);
+      }
+      if (key === 'alt') {
+        return setOpt(true);
+      }
+      if (isCtrl && isOpt && keys.includes(key) && key !== lastKey) {
+        e.preventDefault();
+        setLastKey(key);
+        const combos = [...currentCombos, key];
+        setCurrentCombos(combos);
+        combos.join('') === keys.join('') && setIsActive(!isActive);
+        return;
+      }
+    };
+    const handleKeyUp = (e: KeyboardEvent) => {
+      const key = e.key.toLocaleLowerCase();
+      if (['control', 'alt'].includes(key)) {
+        setCtrl(false);
+        setOpt(false);
+        setCurrentCombos([]);
+      }
+    };
+
+    window.addEventListener('keydown', handleKeyDown);
+    window.addEventListener('keyup', handleKeyUp);
+    return () => {
+      window.removeEventListener('keydown', handleKeyDown);
+      window.removeEventListener('keyup', handleKeyUp);
+    };
+  }, [currentCombos, isActive, isCtrl, isOpt, keys, lastKey]);
+
+  return isActive;
+};
+export default useKeyCombo;

--- a/src/hooks/useKeyCombo.ts
+++ b/src/hooks/useKeyCombo.ts
@@ -9,14 +9,15 @@ export const useKeyCombo = (...keys: string[]) => {
 
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
-      const key = e.key.toLocaleLowerCase();
+      const key = e.key.toLocaleLowerCase('en-US');
+      console.log(key);
       if (key === lastKey) {
         return;
       }
       if (key === 'control') {
         return setCtrl(true);
       }
-      if (key === 'alt') {
+      if (key === 'alt' || key === 'meta') {
         return setOpt(true);
       }
       if (isCtrl && isOpt && keys.includes(key) && key !== lastKey) {


### PR DESCRIPTION
- Handle `private` property on info session object to hide testing dates
- Add easter egg key combo to show/hide private info session dates
- Fix types in `useForm()` hook
- Update info session form submission to read: 
  > **_"Info session registration for submitted. You should receive an email and text message shortly."_**

### Trigger private session dates with 
**Windows:** `ctrl` + `alt` → `O` → `S`
- hold `ctrl` + `alt` then press `O` then `S` while continuing to hold `ctrl` + `alt`

**Mac:** `⌥ control` + `⌘ command` → `O` → `S`
- hold `⌥ control` + `⌘ command` then press `O` then `S` while continuing to hold `⌥ control` + `⌘ command` 