### PR TITLE
remove high school application

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -53,12 +53,16 @@ module.exports = (phase, { defaultConfig }) => {
           destination: '/programs/workforce/infoSession',
           permanent: true,
         },
-        // uncomment to add redirect (when form is not available)
-        // {
-        //   source: '/programs/highschool/apply',
-        //   destination: '/programs/highschool',
-        //   permanent: false,
-        // },
+        /**
+         * High School Application - `/programs/highschool/apply`
+         * comment/uncomment to remove/add redirect (when high school form is (un)available)
+         * Also toggle `SHOW_HS_APPLICATION` in src/components/Navbar/BonusBar.tsx
+         */
+        {
+          source: '/programs/highschool/apply',
+          destination: '/programs/highschool',
+          permanent: false,
+        },
         {
           source: '/privacy',
           destination: '/privacyPolicy',

--- a/src/components/Navbar/BonusBar.tsx
+++ b/src/components/Navbar/BonusBar.tsx
@@ -6,7 +6,14 @@ import NavLink from './elements/NavLink';
 
 const BonusBar = ({ children }: { children?: ReactNode }) => {
   const router = useRouter();
-  const SHOW_HS_APPLICATION = true;
+  /**
+   * High School Application - `/programs/highschool/apply`
+   * - `true` - Show high school application button
+   *   - Uncomment redirect in [next.config.js](../../../next.config.js)
+   * - `false` - Hide high school application button
+   *   - Comment out redirect in  [next.config.js](../../../next.config.js)
+   */
+  const SHOW_HS_APPLICATION = false;
 
   const checkIsPath = (...paths: string[]) => {
     return paths.reduce((isPath, path) => {


### PR DESCRIPTION
Quick change to 
- remove the high school application button
- Add redirect back `/programs/highschool/apply` → `/programs/highschool`
- Add comments for the toggle

TODO: Add main data file for regularly toggled items 
  - Maybe add a login option that allows staff to update 

@harveysanders I tagged you so you are aware but will merge now