### PR TITLE
Disable showcase promo automatically

### DIFF
--- a/src/components/Home/ShowcasePromo.tsx
+++ b/src/components/Home/ShowcasePromo.tsx
@@ -9,9 +9,10 @@ import { toDayJs } from '@this/src/helpers/time';
 
 type ShowcasePromoProps = {
   info: IGradShowcase;
+  clearShowcase: () => void;
 };
 
-const ShowcasePromo: FC<ShowcasePromoProps> = ({ info }) => {
+const ShowcasePromo: FC<ShowcasePromoProps> = ({ info, clearShowcase }) => {
   const showcaseStart = toDayJs(info.startDateTime);
   const doorsOpen = toDayJs(new Date(info.startDateTime)).subtract(30, 'minute');
 
@@ -93,7 +94,7 @@ const ShowcasePromo: FC<ShowcasePromoProps> = ({ info }) => {
             </div>
           </div>
 
-          <CountdownTimer endTime={new Date(info.startDateTime)} />
+          <CountdownTimer endTime={new Date(info.startDateTime)} onComplete={clearShowcase} />
         </div>
 
         <div className='register-section'>

--- a/src/helpers/timeUtils.ts
+++ b/src/helpers/timeUtils.ts
@@ -1,4 +1,5 @@
 import moment from 'moment-timezone';
+import { toDayJs } from './time';
 
 export const toCentTime = (d?: string | Date): Date =>
   moment(typeof d === 'string' ? new Date(d) : d)
@@ -49,4 +50,17 @@ export const getFormattedDateTime = (dateTime?: string | Date | null) => {
     time: d.toLocaleTimeString('en-US', { timeStyle: 'short' }),
     tz: d.toLocaleString('en-US', { timeZoneName: 'short' }).split(' ').pop(),
   };
+};
+
+export const parseShowcaseTime = (endTime?: string): string | null => {
+  if (!endTime) return null;
+  // Force showcase timezone to CT while preserving the hours/minutes
+  const showcaseStart = toDayJs(new Date(endTime)).tz('America/Chicago', true);
+  const now = toDayJs(new Date()).tz('America/Chicago', true);
+
+  if (showcaseStart && !now.isAfter(showcaseStart, 'hour')) {
+    return showcaseStart.toISOString();
+  }
+
+  return null;
 };


### PR DESCRIPTION
### This PR can be merged anytime Monday the 11th

- env variable on vercel has been updated to disable high school application. The update will take effect when merged.
- disable showcase promo at start of the next hour in which the showcase starts. 
**for example:**
  - showcase starts at 5:30pm -- promo will disable at 6:00pm
  - Showcase starts at 6:00pm -- promo will disable at 7:00pm