### PR TITLE
accept `referred_by` query param equal to `snap`

### DIFF
--- a/pages/programs/workforce/infoSession.tsx
+++ b/pages/programs/workforce/infoSession.tsx
@@ -33,8 +33,9 @@ const InfoSession: NextPage<InfoSessionProps> = ({ commonQuestions, logos }) => 
   const [referredBy, setReferredBy] = useState<TOption | undefined>();
 
   useEffect(() => {
-    const { referred_by } = router.query;
-    if (!referred_by || referred_by !== 'snap') return;
+    const { referred_by = '' } = router.query;
+    if (!referred_by || typeof referred_by !== 'string' || referred_by.toLowerCase() !== 'snap')
+      return;
     setReferredBy({ name: 'SNAP', value: 'snap' });
   }, [router.query]);
 

--- a/pages/programs/workforce/infoSession.tsx
+++ b/pages/programs/workforce/infoSession.tsx
@@ -1,6 +1,7 @@
 import styled from 'styled-components';
 import { motion } from 'framer-motion';
 import { GetStaticProps, NextPage } from 'next';
+import { useRouter } from 'next/router';
 import dynamic from 'next/dynamic';
 import Link from 'next/link';
 import { IInfoSession } from '@this/data/types/infoSession';
@@ -12,6 +13,8 @@ import { Main, Section, Content } from '@this/components/layout';
 import useInfoSession from '@this/src/hooks/useInfoSession';
 import { getFormattedDateTime } from '@this/src/helpers/timeUtils';
 import useKeyCombo from '@this/hooks/useKeyCombo';
+import { useEffect, useState } from 'react';
+import { TOption } from '@this/data/types/bits';
 
 const WorkforceForm = dynamic(() => import('@this/src/Forms/Form.Workforce'));
 const Carousel = dynamic(() => import('@this/components/Elements/Carousel'));
@@ -21,10 +24,19 @@ interface InfoSessionProps extends IInfoSession {
 }
 
 const InfoSession: NextPage<InfoSessionProps> = ({ commonQuestions, logos }) => {
+  const router = useRouter();
   const isKeyComboActive = useKeyCombo('o', 's');
   const sessionDates = useInfoSession({ showPrivate: isKeyComboActive });
   const nextSessionDate = sessionDates.find((s) => !s.private);
   const nextSession = getFormattedDateTime(nextSessionDate?.times?.start?.dateTime);
+
+  const [referredBy, setReferredBy] = useState<TOption | undefined>();
+
+  useEffect(() => {
+    const { referred_by } = router.query;
+    if (!referred_by || referred_by !== 'snap') return;
+    setReferredBy({ name: 'SNAP', value: 'snap' });
+  }, [router.query]);
 
   return (
     <Main>
@@ -98,7 +110,7 @@ const InfoSession: NextPage<InfoSessionProps> = ({ commonQuestions, logos }) => 
                   Register for an info session
                 </h2>
 
-                <WorkforceForm sessionDates={sessionDates} />
+                <WorkforceForm sessionDates={sessionDates} referredBy={referredBy} />
               </div>
             </div>
           </Content>

--- a/src/Forms/Form.Workforce.tsx
+++ b/src/Forms/Form.Workforce.tsx
@@ -16,9 +16,10 @@ import { getStateFromZipCode } from '../components/Form/helpers';
 
 interface WorkforceFormProps {
   sessionDates: ISessionDates[];
+  referredBy?: { name: string; value: string };
 }
 
-const WorkforceForm = ({ sessionDates }: WorkforceFormProps) => {
+const WorkforceForm = ({ sessionDates, referredBy }: WorkforceFormProps) => {
   const form = useForm<IInfoSessionFormValues>();
   const [isSubmitting, setIsSubmitting] = useState(false);
 
@@ -168,6 +169,16 @@ const WorkforceForm = ({ sessionDates }: WorkforceFormProps) => {
 
     // eslint-disable-next-line react-hooks/exhaustive-deps -- Ignore form change
   }, [currentValues.sessionDate, currentValues.attendingLocation, sessionDates]);
+
+  useEffect(() => {
+    if (referredBy) {
+      form.onSelectChange('referencedBy')({
+        option: referredBy,
+        isValid: true,
+      });
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- Ignore form change
+  }, [referredBy]);
 
   return (
     <WorkforceFormStyles>
@@ -459,6 +470,10 @@ const referencedByOptions = [
   {
     value: 'tv-streaming',
     name: 'T.V. or Streaming Service',
+  },
+  {
+    value: 'snap',
+    name: 'SNAP',
   },
   {
     value: 'other-advertising',


### PR DESCRIPTION
accept `referred_by` query param equal to `snap` and will autocomplete the referred by field on the info session signup form

### Preview on local
http://localhost:3000/programs/workforce/infoSession?referred_by=snap

### With the query param
<img width="1138" alt="Screenshot 2023-10-23 at 2 41 01 PM" src="https://github.com/OperationSpark/operationspark-org-website-2022/assets/37914211/94700005-5359-44ff-9f6d-5c9c48ac5897">

### Without the query param
<img width="1138" alt="Screenshot 2023-10-23 at 2 41 55 PM" src="https://github.com/OperationSpark/operationspark-org-website-2022/assets/37914211/6c79b715-67ee-4068-8544-4ad842cca482">

