### PR TITLE
Display short url on sign up form after successful signup

### DIFF
--- a/data/gradShowcase.json
+++ b/data/gradShowcase.json
@@ -2,5 +2,5 @@
   "startDateTime": "3/28/2024 18:00",
   "cohortName": "Golf",
   "eventbriteUrl": "https://showcase.operationspark.org/opspark%20website",
-  "isActive": true
+  "isActive": false
 }

--- a/pages/api/infoSession/user.ts
+++ b/pages/api/infoSession/user.ts
@@ -71,7 +71,8 @@ export default async function handleInfoSessionForm(req: ISessionUser, res: Next
   try {
     const payload: ISessionSignup = formatPayload(req.body);
 
-    await runCloudFunction({
+    type SignupResult = { url: string };
+    const result = await runCloudFunction<ISessionSignup, SignupResult>({
       url: SIGNUP_API_ENDPOINT,
       body: payload,
       headers: {
@@ -79,7 +80,7 @@ export default async function handleInfoSessionForm(req: ISessionUser, res: Next
       },
     });
 
-    res.status(200).end();
+    res.status(200).json(result.data);
   } catch (error) {
     console.error('Could not POST to signup service', error);
     res.status(500).end();

--- a/pages/programs/workforce/infoSession.tsx
+++ b/pages/programs/workforce/infoSession.tsx
@@ -11,6 +11,7 @@ import { Content, Main, Section } from '@this/components/layout';
 import { TOption } from '@this/data/types/bits';
 import useKeyCombo from '@this/hooks/useKeyCombo';
 import { getStaticAsset } from '@this/pages-api/static/[asset]';
+import { referencedByOptions } from '@this/src/Forms/formData/referenceOptions';
 import { getFormattedDateTime } from '@this/src/helpers/timeUtils';
 import useInfoSession from '@this/src/hooks/useInfoSession';
 import { cardShadow, cardShadowLtr, cardShadowRtl } from '@this/src/theme/styled/mixins/shadows';
@@ -34,9 +35,35 @@ const InfoSession: NextPage<InfoSessionProps> = ({ commonQuestions, logos }) => 
 
   useEffect(() => {
     const { referred_by = '' } = router.query;
-    if (!referred_by || typeof referred_by !== 'string' || referred_by.toLowerCase() !== 'snap')
+    const referredByStr = Array.isArray(referred_by) ? referred_by[0] : referred_by;
+    if (!referredByStr) return;
+    const [referredType, referredValue] = referredByStr.split('@');
+    const defaultOption = {
+      name: 'Other Advertising',
+      value: 'other-advertising',
+      additionalInfoLabel: 'Where did you hear about us?',
+      additionalInfo: referredType,
+    };
+    const referredByOption = referencedByOptions.find(
+      (option) => option.value === referredType.toLowerCase(),
+    );
+
+    if (!referredByOption) {
+      setReferredBy(defaultOption);
       return;
-    setReferredBy({ name: 'SNAP', value: 'snap' });
+    }
+
+    if (referredByOption.additionalInfo) {
+      referredValue &&
+        setReferredBy({
+          ...referredByOption,
+          additionalInfoLabel: referredByOption.additionalInfo,
+          additionalInfo: referredValue,
+        });
+      return;
+    }
+
+    setReferredBy(referredByOption);
   }, [router.query]);
 
   return (

--- a/src/Forms/Form.Workforce.tsx
+++ b/src/Forms/Form.Workforce.tsx
@@ -70,9 +70,9 @@ const WorkforceForm = ({ sessionDates, referredBy }: WorkforceFormProps) => {
 
     try {
       const { data } = await axios.post('/api/infoSession/user', body);
-
+      const textMessage = currentValues.smsOptIn === 'true' ? ' and text message' : '';
       form.notifySuccess({
-        msg: 'Info session registration for submitted. You should receive an email and text message shortly.',
+        msg: `Info session registration for submitted. You will receive an email${textMessage} shortly.`,
       });
 
       setRenderUrl(data.url);

--- a/src/Forms/Form.Workforce.tsx
+++ b/src/Forms/Form.Workforce.tsx
@@ -69,10 +69,24 @@ const WorkforceForm = ({ sessionDates, referredBy }: WorkforceFormProps) => {
     });
 
     try {
-      const { data } = await axios.post('/api/infoSession/user', body);
+      const { data } = true
+        ? { data: { url: 'https://ospk.org/dvKqYqEJBb' } }
+        : await axios.post('/api/infoSession/user', body);
+
       const textMessage = currentValues.smsOptIn === 'true' ? ' and text message' : '';
+
+      if (currentValues.sessionDate.value === 'future') {
+        form.notifySuccess({
+          msg: `Thank you for signing up! We will reach out soon. You will receive an email ${textMessage} shortly.`,
+        });
+        setRenderUrl(data.url);
+        return setIsSubmitting(false);
+      }
+
+      const sessionDate = currentValues.sessionDate.name;
+      console.log(currentValues.sessionDate.value);
       form.notifySuccess({
-        msg: `Info session registration for submitted. You will receive an email${textMessage} shortly.`,
+        msg: `You have successfully registered for an info session on ${sessionDate}. You will receive an email ${textMessage} shortly.`,
       });
 
       setRenderUrl(data.url);
@@ -111,7 +125,7 @@ const WorkforceForm = ({ sessionDates, referredBy }: WorkforceFormProps) => {
 
   const closeDetails = () => {
     setRenderUrl(null);
-    form.clear();
+    // form.clear(); // TODO: Add back
   };
 
   useEffect(() => {
@@ -374,14 +388,24 @@ const WorkforceForm = ({ sessionDates, referredBy }: WorkforceFormProps) => {
           <div className='form-overlay'>
             <div className='form-complete-response'>
               <h2>Success!</h2>
-              <p>
-                You have successfully registered for an info session on{' '}
-                <b className='primary-secondary'>{currentValues.sessionDate.name}</b>. You will
-                receive an email {currentValues.smsOptIn === 'true' ? 'and text message' : ''}{' '}
-                shortly.
-              </p>
+              {currentValues.sessionDate.value === 'future' ? (
+                <p>
+                  Thank you for signing up! We will reach out soon. You will receive an email{' '}
+                  {currentValues.smsOptIn === 'true' ? 'and text message' : ''} shortly.
+                </p>
+              ) : (
+                <p>
+                  You have successfully registered for an info session on{' '}
+                  <b className='primary-secondary'>{currentValues.sessionDate.name}</b>. You will
+                  receive an email {currentValues.smsOptIn === 'true' ? 'and text message' : ''}{' '}
+                  shortly.
+                </p>
+              )}
               <a href={renderUrl} className='anchor' target='_blank' rel='noreferrer'>
-                View your registration details <NewTabIcon />
+                {currentValues.sessionDate.value === 'future'
+                  ? 'View details'
+                  : 'View your registration details'}
+                <NewTabIcon />
               </a>
               <button onClick={closeDetails}>
                 <CloseIcon className='close-button' />

--- a/src/Forms/Form.Workforce.tsx
+++ b/src/Forms/Form.Workforce.tsx
@@ -13,6 +13,7 @@ import { FormDataSignup } from '@this/pages-api/infoSession/user';
 import Spinner from '../components/Elements/Spinner';
 import { getStateFromZipCode } from '../components/Form/helpers';
 import useKeyCombo from '../hooks/useKeyCombo';
+import { referencedByOptions } from './formData/referenceOptions';
 
 interface WorkforceFormProps {
   sessionDates: ISessionDates[];
@@ -443,56 +444,5 @@ const workforceFormInputs = [
     name: 'phone',
     placeholder: '303-123-9876',
     required: true,
-  },
-];
-
-const referencedByOptions = [
-  {
-    value: 'google',
-    name: 'Google',
-  },
-  {
-    value: 'facebook',
-    name: 'Facebook',
-  },
-  {
-    value: 'instagram',
-    name: 'Instagram',
-  },
-  {
-    value: 'flyer',
-    name: 'Flyer',
-  },
-  {
-    value: 'radio',
-    name: 'Radio Advertising',
-  },
-  {
-    value: 'tv-streaming',
-    name: 'T.V. or Streaming Service',
-  },
-  {
-    value: 'snap',
-    name: 'SNAP',
-  },
-  {
-    value: 'other-advertising',
-    name: 'Other Advertising',
-    additionalInfo: 'Where did you hear about us?',
-  },
-  {
-    value: 'verbal',
-    name: 'Word of mouth',
-    additionalInfo: 'Who told you about us?',
-  },
-  {
-    value: 'event',
-    name: 'Community Event',
-    additionalInfo: 'Which event?',
-  },
-  {
-    value: 'organization',
-    name: 'Community Organization',
-    additionalInfo: 'Which organization?',
   },
 ];

--- a/src/Forms/Form.Workforce.tsx
+++ b/src/Forms/Form.Workforce.tsx
@@ -6,6 +6,7 @@ import styled from 'styled-components';
 
 import Button from '@this/components/Elements/Button';
 import { Form, Input, useForm } from '@this/components/Form';
+import { TOption } from '@this/data/types/bits';
 import { IInfoSessionFormValues } from '@this/data/types/infoSession';
 import { pixel } from '@this/lib/pixel';
 import { ISessionDates } from '@this/pages-api/infoSession/dates';
@@ -17,7 +18,7 @@ import { referencedByOptions } from './formData/referenceOptions';
 
 interface WorkforceFormProps {
   sessionDates: ISessionDates[];
-  referredBy?: { name: string; value: string };
+  referredBy?: TOption;
 }
 
 const WorkforceForm = ({ sessionDates, referredBy }: WorkforceFormProps) => {
@@ -25,12 +26,10 @@ const WorkforceForm = ({ sessionDates, referredBy }: WorkforceFormProps) => {
   const [isSubmitting, setIsSubmitting] = useState(false);
 
   const [locationMessage, setLocationMessage] = useState('');
-
   const isKeyComboActive = useKeyCombo('o', 's');
-
   const currentValues = form.values();
 
-  const handleSubmit = () => {
+  const handleSubmit = async () => {
     const hasErrors = form.hasErrors();
 
     if (hasErrors) {
@@ -172,12 +171,14 @@ const WorkforceForm = ({ sessionDates, referredBy }: WorkforceFormProps) => {
   }, [currentValues.sessionDate, currentValues.attendingLocation, sessionDates]);
 
   useEffect(() => {
-    if (referredBy) {
-      form.onSelectChange('referencedBy')({
-        option: referredBy,
-        isValid: true,
-      });
-    }
+    if (!referredBy) return;
+    form.onSelectChange('referencedBy')({
+      option: referredBy,
+      additionalInfo: referredBy.additionalInfo,
+      additionalInfoLabel: referredBy.additionalInfoLabel,
+      isValid: true,
+    });
+
     // eslint-disable-next-line react-hooks/exhaustive-deps -- Ignore form change
   }, [referredBy]);
 

--- a/src/Forms/Form.Workforce.tsx
+++ b/src/Forms/Form.Workforce.tsx
@@ -34,13 +34,15 @@ const WorkforceForm = ({ sessionDates, referredBy }: WorkforceFormProps) => {
   const currentValues = form.values();
 
   const handleSubmit = async () => {
+    if (isSubmitting) return;
+    setIsSubmitting(true);
     const hasErrors = form.hasErrors();
 
     if (hasErrors) {
+      setIsSubmitting(false);
       return form.toggleShowErrors();
     }
 
-    setIsSubmitting(true);
     const { sessionDate, userLocation, firstName, lastName, ...values } = form.values();
 
     userLocation.value = userLocation.name;

--- a/src/Forms/Form.Workforce.tsx
+++ b/src/Forms/Form.Workforce.tsx
@@ -69,9 +69,7 @@ const WorkforceForm = ({ sessionDates, referredBy }: WorkforceFormProps) => {
     });
 
     try {
-      const { data } = true
-        ? { data: { url: 'https://ospk.org/dvKqYqEJBb' } }
-        : await axios.post('/api/infoSession/user', body);
+      const { data } = await axios.post('/api/infoSession/user', body);
 
       const textMessage = currentValues.smsOptIn === 'true' ? ' and text message' : '';
 
@@ -84,7 +82,7 @@ const WorkforceForm = ({ sessionDates, referredBy }: WorkforceFormProps) => {
       }
 
       const sessionDate = currentValues.sessionDate.name;
-      console.log(currentValues.sessionDate.value);
+
       form.notifySuccess({
         msg: `You have successfully registered for an info session on ${sessionDate}. You will receive an email ${textMessage} shortly.`,
       });
@@ -125,7 +123,7 @@ const WorkforceForm = ({ sessionDates, referredBy }: WorkforceFormProps) => {
 
   const closeDetails = () => {
     setRenderUrl(null);
-    // form.clear(); // TODO: Add back
+    form.clear();
   };
 
   useEffect(() => {

--- a/src/Forms/formData/referenceOptions.ts
+++ b/src/Forms/formData/referenceOptions.ts
@@ -1,0 +1,50 @@
+export const referencedByOptions = [
+  {
+    value: 'google',
+    name: 'Google',
+  },
+  {
+    value: 'facebook',
+    name: 'Facebook',
+  },
+  {
+    value: 'instagram',
+    name: 'Instagram',
+  },
+  {
+    value: 'flyer',
+    name: 'Flyer',
+  },
+  {
+    value: 'radio',
+    name: 'Radio Advertising',
+  },
+  {
+    value: 'tv-streaming',
+    name: 'T.V. or Streaming Service',
+  },
+  {
+    value: 'snap',
+    name: 'SNAP',
+  },
+  {
+    value: 'other-advertising',
+    name: 'Other Advertising',
+    additionalInfo: 'Where did you hear about us?',
+  },
+  {
+    value: 'verbal',
+    name: 'Word of mouth',
+    additionalInfo: 'Who told you about us?',
+  },
+  {
+    value: 'event',
+    name: 'Community Event',
+    additionalInfo: 'Which event?',
+  },
+  {
+    value: 'organization',
+    name: 'Community Organization',
+    additionalInfo: 'Which organization?',
+  },
+];

--- a/src/api/googleFunctions.ts
+++ b/src/api/googleFunctions.ts
@@ -1,3 +1,4 @@
+import { GaxiosPromise } from '@googleapis/calendar';
 import { GoogleAuth } from 'google-auth-library';
 
 export type RunCloudFunctionArgs<T> = {
@@ -6,7 +7,11 @@ export type RunCloudFunctionArgs<T> = {
   headers?: { [key: string]: string | undefined };
 };
 
-export async function runCloudFunction<T>({ url, body, headers = {} }: RunCloudFunctionArgs<T>) {
+export async function runCloudFunction<T, Res>({
+  url,
+  body,
+  headers = {},
+}: RunCloudFunctionArgs<T>): GaxiosPromise<Res> {
   const { GOOGLE_SERVICE_ACCOUNT } = process.env;
   const credentials = GOOGLE_SERVICE_ACCOUNT && JSON.parse(GOOGLE_SERVICE_ACCOUNT);
   if (!credentials) {
@@ -15,7 +20,7 @@ export async function runCloudFunction<T>({ url, body, headers = {} }: RunCloudF
 
   const auth = new GoogleAuth({ credentials });
   const client = await auth.getIdTokenClient(url);
-  await client.request({
+  return await client.request({
     url,
     method: 'POST',
     headers: {

--- a/src/components/Form/Form.tsx
+++ b/src/components/Form/Form.tsx
@@ -1,6 +1,6 @@
+import { MotionProps, motion } from 'framer-motion';
 import { CSSProperties, FormEvent, FormEventHandler, KeyboardEvent, ReactNode } from 'react';
 import styled from 'styled-components';
-import { motion, MotionProps } from 'framer-motion';
 
 const FormStyles = styled(motion.form)`
   display: flex;
@@ -33,6 +33,7 @@ interface FormProps {
 const Form = ({ children, onSubmit, style, motionProps, className, onEnter }: FormProps) => {
   const handleSubmit: FormEventHandler<HTMLFormElement> = (e) => {
     e.preventDefault();
+    e.stopPropagation();
     onSubmit && onSubmit(e);
   };
   return (
@@ -41,7 +42,7 @@ const Form = ({ children, onSubmit, style, motionProps, className, onEnter }: Fo
       className={className}
       onSubmit={handleSubmit}
       style={style}
-      onKeyDown={onEnter}
+      onKeyDown={(e) => e.key === 'Enter' && onEnter?.(e)}
       {...motionProps}
     >
       {children}


### PR DESCRIPTION
- [x] Fix unexpected input clear on enter
- [x] Dynamically set referredBy field(s) if `referred_by` query params exists. For example:
  - SNAP: `/programs/workforce/infoSession?referred_by=snap`
  - Google: `/programs/workforce/infoSession?referred_by=google`
  - Word of Mouth: `/programs/workforce/infoSession?referred_by=verbal@hallebot`
  - Custom: `/programs/workforce/infoSession?referred_by=AnyValue`
- [x] Display success message, info session date time, and renderer URL upon successful signup. Resolves #142 


https://github.com/OperationSpark/operationspark-org-website-2022/assets/37914211/e77f66fc-ab05-4f03-a41a-d698401c8ce6

