### PR TITLE
use showcase api data to determine showcase active status

### DIFF
--- a/data/types/gradShowcase.d.ts
+++ b/data/types/gradShowcase.d.ts
@@ -4,3 +4,23 @@ export interface IGradShowcase {
   eventbriteUrl: string;
   isActive: boolean;
 }
+
+export type Showcase = {
+  id: string;
+  cohortName: string;
+  startDateTime: Date;
+  timezone: string;
+  /** Minutes before event start time */
+  doorsOffset: number;
+  /** Minutes after start to disable registration/zoom */
+  disableOffset: number; // TODO
+  zoomUrl: string;
+  teams: Record<string, unknown>[];
+  promoBanner?: { url: string };
+  active: boolean;
+  signups: string[];
+  ticketCount: number;
+  websiteActive?: boolean;
+  createdAt?: Date;
+  updatedAt?: Date;
+};

--- a/src/components/Home/ShowcasePromo.tsx
+++ b/src/components/Home/ShowcasePromo.tsx
@@ -2,13 +2,13 @@ import { FC, useEffect, useState } from 'react';
 import styled, { keyframes } from 'styled-components';
 
 import Content from '@this/components/layout/Content';
-import { circuitBoardBg } from '@this/src/theme/styled/mixins/circuitBoardBg';
-import { IGradShowcase } from '@this/data/types/gradShowcase';
-import { CountdownTimer } from '../Elements/Countdown';
+import { Showcase } from '@this/data/types/gradShowcase';
 import { toDayJs } from '@this/src/helpers/time';
+import { circuitBoardBg } from '@this/src/theme/styled/mixins/circuitBoardBg';
+import { CountdownTimer } from '../Elements/Countdown';
 
 type ShowcasePromoProps = {
-  info: IGradShowcase;
+  info: Showcase;
   clearShowcase: () => void;
 };
 
@@ -102,7 +102,7 @@ const ShowcasePromo: FC<ShowcasePromoProps> = ({ info, clearShowcase }) => {
             className='showcase-website-button'
             onClick={() =>
               window.open(
-                'https://showcase.operationspark.org/Operation%20Spark%20Website',
+                'https://showcase.operationspark.org/share/Operation%20Spark%20Website',
                 '_blank',
               )
             }


### PR DESCRIPTION
fetch active showcase from `showcase.operationspark.org/api.showcases/active`
- Showcase can be toggled active/inactive from. the showcase admin view
- Website promo can be toggled active/inactive from the 