### PR TITLE
remove "day" from form 

### DIFF
--- a/pages/api/infoSession/dates.ts
+++ b/pages/api/infoSession/dates.ts
@@ -5,7 +5,7 @@ import { getConfig } from '@this/config';
 import { GooglePlace, LocationType } from '@this/types/signups';
 
 export type DateTime = {
-  dateTime: string;
+  dateTime: string | Date;
   timeZone: 'America/Chicago';
 };
 
@@ -18,7 +18,7 @@ export interface ISessionDates {
   times: {
     start: DateTime;
     end: DateTime;
-    until: string;
+    until: string | Date;
     byday: 'MO' | 'TU' | 'WE' | 'TH' | 'FR' | 'SA' | 'SU';
   };
   googlePlace: GooglePlace;

--- a/src/Forms/Form.Workforce.tsx
+++ b/src/Forms/Form.Workforce.tsx
@@ -73,7 +73,7 @@ const WorkforceForm = ({ sessionDates, referredBy }: WorkforceFormProps) => {
           cohort: session.cohort,
           programId: session.programId,
           code: session.code,
-          startDateTime: session.times.start.dateTime,
+          startDateTime: session.times.start.dateTime as string,
           googlePlace: session.googlePlace,
           locationType: session.locationType,
         },


### PR DESCRIPTION
After discussing earlier, it turns out that we are not doing info sessions on Thursdays. This PR removes the `day` from `findBestSession`

- rework how best session is determined
  - updated tests accordingly 

### TODO (Upon Deployment)

- [ ] Update [webhook URL](https://developers.facebook.com/apps/963941362163995/webhooks/?business_id=1717012455274208) -- Get key from [vercel vars](https://vercel.com/operation-spark/opspark-website-2022/settings/environment-variables)
  ```diff
  - https://opspark.ngrok.io/api/signups/info/facebook
  + https://www.operationspark.org/api/signups/info/facebook
  ```
> Note: In the future, we will need to create a development app
